### PR TITLE
feat: allow using a custom markdown renderer

### DIFF
--- a/markdown.tsx
+++ b/markdown.tsx
@@ -94,7 +94,11 @@ function parseLinks(
   return markdown;
 }
 
-function mdToHtml(markdown: string, url: string, namespace?: string): string {
+export function mdToHtml(
+  markdown: string,
+  url: string,
+  namespace?: string,
+): string {
   return syntaxHighlight(
     comrak.markdownToHTML(
       parseLinks(markdown, url, namespace),
@@ -122,7 +126,7 @@ export function Markdown(
         class={style(markdownStyle)}
         id={id}
         dangerouslySetInnerHTML={{
-          __html: mdToHtml(md, url, namespace),
+          __html: services.markdownToHTML(md, url, namespace),
         }}
       />
     )
@@ -139,7 +143,9 @@ export function MarkdownSummary(
     ? (
       <span
         class={style(markdownStyle)}
-        dangerouslySetInnerHTML={{ __html: mdToHtml(md, url, namespace) }}
+        dangerouslySetInnerHTML={{
+          __html: services.markdownToHTML(md, url, namespace),
+        }}
       />
     )
     : null;

--- a/services.ts
+++ b/services.ts
@@ -54,8 +54,6 @@ export interface Configuration {
   runtime?: JsxRuntime;
   /** If provided, the twind {@linkcode twSetup setup} will be performed. */
   tw?: TwConfiguration;
-  /** If set to true, will disable the loading of comrak. */
-  useCustomMarkdownRenderer?: boolean;
 }
 
 export const theme: ThemeConfiguration = {
@@ -138,7 +136,7 @@ const runtimeConfig: Required<
 
 /** Setup the services used by the doc components. */
 export async function setup(config: Configuration) {
-  const { runtime, tw, useCustomMarkdownRenderer, ...other } = config;
+  const { runtime, tw, ...other } = config;
   Object.assign(runtimeConfig, other);
   if (runtime) {
     Object.assign(runtimeConfig.runtime, runtime);
@@ -146,7 +144,7 @@ export async function setup(config: Configuration) {
   if (tw) {
     twSetup(tw);
   }
-  if (!useCustomMarkdownRenderer) {
+  if (!other.markdownToHTML) {
     await comrak.init();
   }
 }


### PR DESCRIPTION
Alternative solution to #4, so dotland can use gfm