### PR TITLE
refactor: switch resolveHref to use URL

### DIFF
--- a/_showcase/main.tsx
+++ b/_showcase/main.tsx
@@ -31,22 +31,22 @@ const page = "/";
 await setup({
   lookupHref(url, namespace, symbol) {
     return namespace
-      ? `/${url}/~/${namespace}.${symbol}`
-      : `/${url}/~/${symbol}`;
+      ? `/${url.href}/~/${namespace}.${symbol}`
+      : `/${url.href}/~/${symbol}`;
   },
   resolveHref(url, symbol) {
     if (symbol) {
-      return `https://doc.deno.land/${url}/~/${symbol}`;
+      return `https://doc.deno.land/${url.href}/~/${symbol}`;
     }
     const pattern = new URLPattern(
       "https://deno.land/x/:module@:version/:path*",
     );
-    const result = pattern.exec(url);
+    const result = pattern.exec(url.href);
     if (result) {
       const { module, version, path } = result.pathname.groups;
       return `${page}/${module}/${version}/${path}`;
     }
-    return `/${url}`;
+    return `/${url.href}`;
   },
   runtime: { Fragment, h },
   tw: { sheet, theme, plugins, darkMode: "class" },
@@ -61,7 +61,7 @@ router.get("/", async (ctx, next) => {
   const symbolDoc = await getSymbolDoc();
   const body = renderSSR(
     <Showcase
-      url="https://deno.land/x/oak@v11.0.0/mod.ts"
+      url={new URL("https://deno.land/x/oak@v11.0.0/mod.ts")}
       symbol="Application"
       moduleIndex={moduleIndex}
       moduleDoc={moduleDoc}
@@ -94,7 +94,7 @@ router.get("/docblocks", async (ctx, next) => {
   ];
   const body = renderSSR(
     <ShowcaseDocBlocks
-      url="https://deno.land/x/oak@v10.6.0/mod.ts"
+      url={new URL("https://deno.land/x/oak@v10.6.0/mod.ts")}
       docNodes={docNodes}
     />,
   );

--- a/_showcase/showcase.tsx
+++ b/_showcase/showcase.tsx
@@ -57,7 +57,7 @@ function ComponentTitle(
 
 export function Showcase(
   { moduleIndex, moduleDoc, symbolDoc, symbol, url }: {
-    url: string;
+    url: URL;
     symbol: string;
     moduleIndex: any;
     moduleDoc: any;
@@ -78,7 +78,7 @@ export function Showcase(
 
       <ComponentTitle module="/module_index.tsx">ModuleIndex</ComponentTitle>
       <ModuleIndex
-        base="https://deno.land/std@0.154.0"
+        url={new URL("https://deno.land/std@0.154.0")}
         sourceUrl="https://deno.land/std@0.154.0"
       >
         {moduleIndex.items}
@@ -88,7 +88,7 @@ export function Showcase(
         ModuleIndexPanel
       </ComponentTitle>
       <ModuleIndexPanel
-        base="https://deno.land/oak@v11.0.0"
+        base={new URL("https://deno.land/oak@v11.0.0")}
         path="/mod.ts"
         current="/mod.ts"
       >
@@ -96,7 +96,7 @@ export function Showcase(
       </ModuleIndexPanel>
 
       <ComponentTitle module="/module_doc.tsx">ModuleDoc</ComponentTitle>
-      <ModuleDoc url={url} sourceUrl={url}>
+      <ModuleDoc url={url} sourceUrl={url.href}>
         {moduleDoc.docNodes}
       </ModuleDoc>
 
@@ -126,7 +126,7 @@ export function Showcase(
 }
 
 export function ShowcaseDocBlocks(
-  { docNodes, url }: { docNodes: DocNode[]; url: string },
+  { docNodes, url }: { docNodes: DocNode[]; url: URL },
 ) {
   const classNode = docNodes.find(({ kind }) =>
     kind === "class"

--- a/doc/library_category_panel.tsx
+++ b/doc/library_category_panel.tsx
@@ -20,7 +20,7 @@ export interface SymbolItem {
 function Symbol(
   { children, base, active, currentSymbol, uncategorized }: {
     children: Child<SymbolItem>;
-    base: string;
+    base: URL;
     active: boolean;
     currentSymbol?: string;
     uncategorized?: boolean;
@@ -58,7 +58,7 @@ function Category(
   { children, base, name, currentSymbol }: {
     children: Child<SymbolItem[]>;
     name: string;
-    base: string;
+    base: URL;
     currentSymbol?: string;
   },
 ) {
@@ -98,7 +98,7 @@ function Category(
 export function LibraryCategoryPanel(
   { children, base, currentSymbol }: {
     children: Child<SymbolItem[]>;
-    base: string;
+    base: URL;
     currentSymbol?: string;
   },
 ) {

--- a/doc/markdown.tsx
+++ b/doc/markdown.tsx
@@ -47,7 +47,7 @@ function isLink(link: string): boolean {
 
 function parseLinks(
   markdown: string,
-  url: string,
+  url: URL,
   namespace?: string,
 ): string {
   let match;
@@ -96,7 +96,7 @@ function parseLinks(
 
 export function mdToHtml(
   markdown: string,
-  url: string,
+  url: URL,
   namespace?: string,
 ): string {
   return syntaxHighlight(
@@ -108,7 +108,7 @@ export function mdToHtml(
 }
 
 export interface MarkdownContext {
-  url: string;
+  url: URL;
   namespace?: string;
   markdownStyle?: StyleKey;
   replace?: [string, string];

--- a/doc/module_doc.tsx
+++ b/doc/module_doc.tsx
@@ -182,10 +182,10 @@ export function ModuleDoc(
       </div>
       <article class={style("main")}>
         {maybe(
-          !(library || markdownContext.url.endsWith(".d.ts")),
+          !(library || markdownContext.url.pathname.endsWith(".d.ts")),
           <div class={style("moduleDoc")}>
             <div class={tw`space-y-3`}>
-              <Usage url={markdownContext.url} />
+              <Usage url={markdownContext.url.href} />
               {collection.moduleDoc && (
                 <JsDocModule markdownContext={markdownContext}>
                   {collection.moduleDoc}

--- a/doc/module_index.tsx
+++ b/doc/module_index.tsx
@@ -23,7 +23,8 @@ function Folder({ children, parent, markdownContext }: {
   markdownContext: MarkdownContext;
 }) {
   const item = take(children);
-  const url = `${markdownContext.url}${item.path}`;
+  const url = new URL(markdownContext.url);
+  url.pathname += item.path;
   const href = services.resolveHref(url);
   const summary = getSummary(item.doc);
   const label = item.path.slice(parent === "/" ? 1 : parent.length + 1);
@@ -48,7 +49,8 @@ function Module({ children, parent, markdownContext }: {
   markdownContext: MarkdownContext;
 }) {
   const item = take(children);
-  const url = `${markdownContext.url}${item.path}`;
+  const url = new URL(markdownContext.url);
+  url.pathname += item.path;
   const href = services.resolveHref(url);
   const summary = getSummary(item.doc);
   const label = item.path.slice(parent === "/" ? 1 : parent.length + 1);

--- a/doc/module_index_panel.tsx
+++ b/doc/module_index_panel.tsx
@@ -47,11 +47,12 @@ export function splitItems(
 
 function Folder({ children, base, parent }: {
   children: Child<string>;
-  base: string;
+  base: URL;
   parent: string;
 }) {
   const folderName = take(children);
-  const url = `${base}${folderName}`;
+  const url = new URL(base);
+  url.pathname += folderName;
   const href = services.resolveHref(url);
   const label = folderName.slice(parent === "/" ? 1 : parent.length + 1);
   return (
@@ -65,7 +66,7 @@ function Folder({ children, base, parent }: {
 function Module(
   { children, base, parent, current, currentSymbol, isIndex }: {
     children: Child<DocPageModuleItem>;
-    base: string;
+    base: URL;
     parent: string;
     current?: string;
     currentSymbol?: string;
@@ -73,7 +74,8 @@ function Module(
   },
 ) {
   const { path, items } = take(children);
-  const url = `${base}${path}`;
+  const url = new URL(base);
+  url.pathname += path;
   const href = services.resolveHref(url);
   const label = path.slice(parent === "/" ? 1 : parent.length + 1);
   const active = current ? current == path : isIndex;
@@ -132,7 +134,7 @@ function Module(
 export function ModuleIndexPanel(
   { children, path = "/", base, current, currentSymbol }: {
     children: Child<DocPageNavItem[]>;
-    base: string;
+    base: URL;
     path: string;
     current?: string;
     currentSymbol?: string;

--- a/doc/symbol_doc.tsx
+++ b/doc/symbol_doc.tsx
@@ -48,7 +48,7 @@ export function SymbolDoc(
   const title = markdownContext.namespace
     ? `${markdownContext.namespace}.${docNodes[0].name}`
     : docNodes[0].name;
-  const showUsage = !(markdownContext.url.endsWith(".d.ts") || library);
+  const showUsage = !(markdownContext.url.href.endsWith(".d.ts") || library);
 
   return (
     <article class={style("symbolDoc")}>
@@ -140,7 +140,7 @@ function Symbol(
       <div class={tw`space-y-3`}>
         {showUsage && (
           <Usage
-            url={markdownContext.url}
+            url={markdownContext.url.href}
             name={title}
             isType={isTypeOnly(docNodes)}
           />

--- a/services.ts
+++ b/services.ts
@@ -34,7 +34,7 @@ export interface Configuration {
    * ascending to global scopes to resolve the href. If the symbol cannot be
    * found, the function should return `undefined`. */
   lookupHref?: (
-    url: string,
+    url: URL,
     namespace: string | undefined,
     symbol: string,
   ) => string | undefined;
@@ -45,7 +45,7 @@ export interface Configuration {
    *
    * Implementors should return a string which will be used as the `href` value
    * for a link. */
-  resolveHref?: (url: string, symbol?: string) => string;
+  resolveHref?: (url: URL, symbol?: string) => string;
   /** Called when doc components are trying to generate a link to a source file.
    *
    * Implementors should return a string which which will be used as the `href`
@@ -55,7 +55,7 @@ export interface Configuration {
   /** Called when markdown needs to be rendered. */
   markdownToHTML?: (
     markdown: string,
-    url: string,
+    url: URL,
     namespace?: string,
   ) => string;
   /** The JSX runtime that should be used. */
@@ -199,14 +199,14 @@ export const runtime: JsxRuntime = {
 
 export const services = {
   /** Return a link to the provided URL and optional symbol. */
-  get resolveHref(): (url: string, symbol?: string) => string {
+  get resolveHref(): (url: URL, symbol?: string) => string {
     return runtimeConfig.resolveHref;
   },
 
   /** Attempt to find a link to a specific symbol from the current URL and
    * optionally namespace. */
   get lookupHref(): (
-    url: string,
+    url: URL,
     namespace: string | undefined,
     symbol: string,
   ) => string | undefined {
@@ -220,7 +220,7 @@ export const services = {
   /** Render Markdown to HTML */
   get markdownToHTML(): (
     markdown: string,
-    url: string,
+    url: URL,
     namespace?: string,
   ) => string {
     return runtimeConfig.markdownToHTML;


### PR DESCRIPTION
Needed for better handling of search params for more complex states (i.e. handling of unstable search param on dotland)