### PR TITLE
fix: carefully construct onClick attribute to make copy buttons work

### DIFF
--- a/doc/usage.tsx
+++ b/doc/usage.tsx
@@ -99,7 +99,7 @@ export function Usage(
         </code>
         <button
           class={style("copyButton")}
-          onClick={`navigator?.clipboard?.writeText("${importStatement}");`}
+          onClick={`navigator?.clipboard?.writeText('${importStatement.trim()}');`}
         >
           <Icons.Copy />
         </button>


### PR DESCRIPTION
Fixes #31

With this PR, copy buttons will work fine. What's done are:

- to use single quotes to avoid getting unintentional escape characters
- to call `trim()` to avoid getting unnecessary newline character that prevents the click handler from working

I confirmed that it works as expected using the showcase implementation in this repo, although there were a couple of type errors to be resolved to get it to work, which is already reported in #21.

