### PR TITLE
fix: typo in type documentation

### DIFF
--- a/doc/type_aliases.tsx
+++ b/doc/type_aliases.tsx
@@ -31,7 +31,7 @@ export function DocBlockTypeAlias(
         id={id}
         location={def.location}
         tags={tags}
-        name={"defintion"}
+        name={"definition"}
         markdownContext={markdownContext}
       >
         :{" "}


### PR DESCRIPTION
I noticed this typo here: https://deno.land/std@0.156.0/encoding/csv_stringify.ts?doc=&s=ColumnDetails