### PR TITLE
feat: messages for empty module docs

### DIFF
--- a/_showcase/components/ShowcaseModuleDoc.tsx
+++ b/_showcase/components/ShowcaseModuleDoc.tsx
@@ -1,0 +1,53 @@
+import { apply, tw } from "twind";
+import { css } from "twind/css";
+import { type DocNode } from "@doc_components/deps.ts";
+
+import { ModuleDoc } from "@doc_components/doc/module_doc.tsx";
+
+import { ComponentLink } from "./ComponentLink.tsx";
+import { ComponentTitle } from "./ComponentTitle.tsx";
+
+const app = css({
+  ":global": {
+    "html": apply`bg(white dark:gray-900)`,
+  },
+});
+
+export function ShowcaseModuleDoc({ url }: { url: URL }) {
+  const noExportsDocNodes: DocNode[] = [{
+    kind: "import",
+    declarationKind: "private",
+    importDef: { src: "https://deno.land/x/std/testing/asserts.ts" },
+    name: "assert",
+    location: {
+      filename: "https://deno.land/x/oak@v11.1.0/mod.ts",
+      col: 12,
+      line: 1,
+    },
+  }];
+  return (
+    <div
+      class={tw`bg-white dark:(bg-gray-900 text-white) ${app} max-w-screen-xl mx-auto my-4 p-4`}
+    >
+      <h1 class="text-3xl py-3">Deno Doc Components</h1>
+      <h2 class="text-2xl py-2 border-b-1">DocBlock Component Showcase</h2>
+      <nav class="py-4 border-b-1">
+        <h3 class="text-xl">Component List</h3>
+        <ul class="list-disc mx-6 my-2">
+          <ComponentLink>ModuleDoc - Empty</ComponentLink>
+          <ComponentLink>ModuleDoc - No Exports</ComponentLink>
+        </ul>
+      </nav>
+
+      <ComponentTitle module="/doc/module_doc.tsx">
+        ModuleDoc - Empty
+      </ComponentTitle>
+      <ModuleDoc url={url} sourceUrl={url.href}>{[]}</ModuleDoc>
+
+      <ComponentTitle module="/doc/module_doc.tsx">
+        ModuleDoc - No Exports
+      </ComponentTitle>
+      <ModuleDoc url={url} sourceUrl={url.href}>{noExportsDocNodes}</ModuleDoc>
+    </div>
+  );
+}

--- a/_showcase/fresh.gen.ts
+++ b/_showcase/fresh.gen.ts
@@ -5,11 +5,13 @@
 import config from "./deno.json" assert { type: "json" };
 import * as $0 from "./routes/docblocks.tsx";
 import * as $1 from "./routes/index.tsx";
+import * as $2 from "./routes/moduledoc.tsx";
 
 const manifest = {
   routes: {
     "./routes/docblocks.tsx": $0,
     "./routes/index.tsx": $1,
+    "./routes/moduledoc.tsx": $2,
   },
   islands: {},
   baseUrl: import.meta.url,

--- a/_showcase/routes/docblocks.tsx
+++ b/_showcase/routes/docblocks.tsx
@@ -17,7 +17,7 @@ export default function DocBlocks({ data }: PageProps<Data>) {
   return (
     <>
       <Head>
-        <title>doc_components Showcase</title>
+        <title>doc_components Showcase | DocBlocks</title>
       </Head>
       <ShowcaseDocBlocks url={new URL("https://deno.land/x/oak@v11.1.0/")}>
         {data}

--- a/_showcase/routes/moduledoc.tsx
+++ b/_showcase/routes/moduledoc.tsx
@@ -1,0 +1,13 @@
+import { Head } from "$fresh/runtime.ts";
+import { ShowcaseModuleDoc } from "../components/ShowcaseModuleDoc.tsx";
+
+export default function ModuleDocs() {
+  return (
+    <>
+      <Head>
+        <title>doc_components Showcase | ModuleDoc</title>
+      </Head>
+      <ShowcaseModuleDoc url={new URL("htps://deno.land/x/oak@v11.1.0/")} />
+    </>
+  );
+}

--- a/doc/module_doc.tsx
+++ b/doc/module_doc.tsx
@@ -162,7 +162,12 @@ export function ModuleDoc(
     sourceUrl: string;
   } & Pick<Context, "url" | "replacers">,
 ) {
-  const collection = asCollection(take(children, true));
+  const docNodes = take(children, true);
+  const isEmpty = docNodes.length === 0;
+  const hasExports = docNodes.some(({ declarationKind, kind }) =>
+    kind !== "moduleDoc" && declarationKind === "export"
+  );
+  const collection = asCollection(docNodes);
   return (
     <div>
       <div class={style("moduleDocHeader")}>
@@ -176,17 +181,31 @@ export function ModuleDoc(
       </div>
       <article class={style("main")}>
         <div class={style("moduleDoc")}>
-          <div class={tw`space-y-3`}>
-            <Usage url={context.url} />
+          <div class="space-y-3">
+            {isEmpty || hasExports ? <Usage url={context.url} /> : undefined}
             {collection.moduleDoc && (
               <JsDocModule context={context}>
                 {collection.moduleDoc}
               </JsDocModule>
             )}
           </div>
-          <DocTypeSections context={context}>
-            {collection}
-          </DocTypeSections>
+          {isEmpty
+            ? (
+              <div class="mx-8 p-4 border border-yellow-700 bg-yellow-50 text-yellow-700 rounded-lg text-center italic">
+                The documentation for this module is currently unavailable.
+              </div>
+            )
+            : hasExports
+            ? (
+              <DocTypeSections context={context}>
+                {collection}
+              </DocTypeSections>
+            )
+            : (
+              <div class="mx-8 p-4 border border-blue-700 bg-blue-50 text-blue-700 rounded-lg text-center italic">
+                This module does not provide any exports.
+              </div>
+            )}
         </div>
       </article>
     </div>


### PR DESCRIPTION
This provides information to the user when attempting to view a module that either doesn't have documentation for various reasons or doesn't export anything.  Examples can be seen in the showcase here: https://deno-doc-components-cy55qm7ef6j0.deno.dev/moduledoc