### PR TITLE
feat: display multiple symbol kinds as a single symbol

### DIFF
--- a/doc/module_index_panel.tsx
+++ b/doc/module_index_panel.tsx
@@ -1,6 +1,6 @@
 // Copyright 2021-2022 the Deno authors. All rights reserved. MIT license.
 
-import { DocNodeKind, JsDoc } from "../deps.ts";
+import { type DocNodeKind, type JsDoc, tw } from "../deps.ts";
 import { byKindValue, getIndex } from "./doc.ts";
 import { services } from "../services.ts";
 import { style } from "../styles.ts";
@@ -78,6 +78,22 @@ function Module(
   const href = services.resolveHref(url);
   const label = path.slice(parent === "/" ? 1 : parent.length + 1);
   const active = current ? current == path : isIndex;
+
+  const symbols: Record<string, DocNodeKind[]> = {};
+  for (
+    const symbolItem of items.filter((symbol) =>
+      symbol.kind !== "import" && symbol.kind !== "moduleDoc"
+    ).sort((a, b) =>
+      byKindValue(a.kind, b.kind) || a.name.localeCompare(b.name)
+    )
+  ) {
+    if (symbolItem.name in symbols) {
+      symbols[symbolItem.name].push(symbolItem.kind);
+    } else {
+      symbols[symbolItem.name] = [symbolItem.kind];
+    }
+  }
+
   return (
     <details
       open={!!(active && currentSymbol)}
@@ -104,28 +120,23 @@ function Module(
         </a>
       </summary>
 
-      {items.filter((symbol) =>
-        symbol.kind !== "import" && symbol.kind !== "moduleDoc"
-      ).sort((a, b) =>
-        byKindValue(a.kind, b.kind) || a.name.localeCompare(b.name)
-      ).map((symbol) => {
-        const Icon = docNodeKindMap[symbol.kind];
-        return (
-          <a
-            class={style("moduleIndexPanelSymbol") +
-              ((active && currentSymbol === symbol.name)
-                ? " " + style("moduleIndexPanelActive")
-                : "")}
-            href={services.resolveHref(url, symbol.name)}
-            title={symbol.name}
-          >
-            <span>
-              <Icon />
-              <span>{symbol.name}</span>
-            </span>
-          </a>
-        );
-      })}
+      {Object.entries(symbols).map(([name, kinds]) => (
+        <a
+          class={style("moduleIndexPanelSymbol") +
+            ((active && currentSymbol === name)
+              ? " " + style("moduleIndexPanelActive")
+              : "")}
+          href={services.resolveHref(url, name)}
+          title={name}
+        >
+          <span>
+            <div class={tw`${style("symbolKindDisplay")} justify-end`}>
+              {kinds.map((kind) => docNodeKindMap[kind]())}
+            </div>
+            <span>{name}</span>
+          </span>
+        </a>
+      ))}
     </details>
   );
 }

--- a/styles.ts
+++ b/styles.ts
@@ -76,7 +76,7 @@ const styles = {
     apply`flex items-center gap-2 py-2 px-3 rounded-lg w-full leading-6 hover:(text-gray-500  bg-gray-50) children:last-child:(truncate flex-shrink-1)`,
   moduleIndexPanelModuleIndex: apply`text-[#6C6E78] font-light`,
   moduleIndexPanelSymbol:
-    apply`flex items-center justify-between gap-1 py-1.5 pl-7 pr-3 rounded-lg w-full leading-6 hover:(text-gray-500 bg-gray-50) children:first-child:(flex items-center gap-2 min-w-0 children:last-child:truncate)`,
+    apply`flex items-center justify-between gap-1 py-1.5 pl-2.5 pr-3 rounded-lg w-full leading-6 hover:(text-gray-500 bg-gray-50) children:first-child:(flex items-center gap-2 min-w-0 children:last-child:truncate)`,
   section: apply`text-sm leading-6 font-semibold text-gray-400 py-1`,
   symbolDoc: apply`space-y-12 md:(col-span-3)`,
   symbolDocHeader: apply`flex justify-between items-start`,
@@ -89,6 +89,8 @@ const styles = {
   symbolListCellDoc: apply`block lg:table-cell py-1 text-sm text-[#9CA0AA]`,
   symbolListRow: apply`block lg:table-row`,
   symbolListTable: apply`block lg:table`,
+  symbolKindDisplay:
+    apply`w-11 flex-none flex children:(not-first-child:-ml-[7px])`,
   tag:
     apply`inline-flex items-center gap-0.5 children:flex-none rounded-full font-medium text-sm leading-none font-sans`,
 } as const;


### PR DESCRIPTION
Closes denoland/dotland#2483
<img width="226" alt="Screenshot 2022-11-22 at 13 48 59" src="https://user-images.githubusercontent.com/13135287/203318024-4e4ed434-a03f-4f7e-89d0-4e279684219f.png">

Example previews:
library index: https://dotland-pcw2qz4nw9s0.deno.dev/api@v1.28.1
library sidepanel: https://dotland-pcw2qz4nw9s0.deno.dev/api@v1.28.1?s=FormData
module sidepanel: https://dotland-pcw2qz4nw9s0.deno.dev/x/zod@v3.18.0/mod.ts?s=ZodIssueCode

The only problem with this is that module index (https://dotland-pcw2qz4nw9s0.deno.dev/x/zod@v3.18.0/mod.ts) is sectioned by symbol kind, so it could be weird if we do this there. 
