### PR TITLE
Use unique ids for footer elements

### DIFF
--- a/footer.tsx
+++ b/footer.tsx
@@ -97,16 +97,18 @@ export function Footer() {
 function FooterSection(
   { title, entries }: { title: string; entries: Record<string, string> },
 ) {
+  // Make sure we have a unique Id because some entries title are common in the code base
+  const id = "Footer" + title;
   return (
     <div>
       <input
         type="checkbox"
-        id={title}
+        id={id}
         class="hidden checked:(siblings:last-child:flex sibling:children:last-child:children:(odd:hidden even:block))"
         autoComplete="off"
       />
       <label
-        htmlFor={title}
+        htmlFor={id}
         tabIndex={0}
         class="flex items-center justify-between px-1 my-3 lg:(px-0 my-0)"
       >


### PR DESCRIPTION
This fixes the + button on Community
![image](https://user-images.githubusercontent.com/22427111/221378725-970151a9-19d7-44bb-9802-bd0b12e2ed75.png)
 
It used to clash with Header which also have an element with the id Community