### PR TITLE
fix: don't render `@link` for broken links

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -49,9 +49,9 @@ export type {
   TsTypeUnionDef,
 } from "https://deno.land/x/deno_doc@0.56.0/lib/types.d.ts";
 
-export { toHtml } from "https://esm.sh/hast-util-to-html@8.0.3?pin=v87";
-export * as htmlEntities from "https://esm.sh/html-entities@2.3.3?pin=v87";
-export { lowlight } from "https://esm.sh/lowlight@2.7.0?pin=v87";
+export { toHtml } from "https://esm.sh/hast-util-to-html@8.0.3";
+export * as htmlEntities from "https://esm.sh/html-entities@2.3.3";
+export { lowlight } from "https://esm.sh/lowlight@2.7.0";
 export {
   apply,
   type Configuration,

--- a/doc/markdown.tsx
+++ b/doc/markdown.tsx
@@ -90,8 +90,8 @@ function parseLinks(markdown: string, url: URL, namespace?: string): string {
       }
     } else {
       replacement = modifier === "code"
-        ? `{_@link_ \`${link}\`${title ? ` | ${title}` : ""}}`
-        : `{_@link_ ${link}${title ? ` | ${title}` : ""}}`;
+        ? `\`${link}\`${title ? ` | ${title}` : ""}`
+        : `${link}${title ? ` | ${title}` : ""}`;
     }
     markdown = `${markdown.slice(0, match.index)}${replacement}${
       markdown.slice(match.index + text.length)


### PR DESCRIPTION
For cases such as http://deno.land/api@v1.32.5?unstable=&s=Deno.Kv&p=prototype.atomic