### PR TITLE
feat: better re-export handling

### DIFF
--- a/doc/doc_common.tsx
+++ b/doc/doc_common.tsx
@@ -206,6 +206,7 @@ export function Tag(
 }
 
 export const tagVariants = {
+  reExportLg: () => <Tag color="purple" large>Re-export</Tag>,
   deprecatedLg: () => (
     <Tag color="gray" large>
       <Icons.ExclamationMark />

--- a/doc/symbol_doc.tsx
+++ b/doc/symbol_doc.tsx
@@ -44,7 +44,12 @@ export function SymbolDoc(
   const docNodes = [...take(children, true)];
   docNodes.sort(byKind);
   let splitNodes: Record<string, DocNode[]> = {};
+  let isReExport = false;
   for (const docNode of docNodes) {
+    if (docNode.kind === "import") {
+      isReExport = true;
+      continue;
+    }
     if (!(docNode.kind in splitNodes)) {
       splitNodes[docNode.kind] = [];
     }
@@ -88,6 +93,7 @@ export function SymbolDoc(
           showUsage={showUsage}
           property={propertyName}
           name={name}
+          isReExport={isReExport}
           context={context}
         >
           {nodes}
@@ -98,11 +104,12 @@ export function SymbolDoc(
 }
 
 function Symbol(
-  { children, showUsage, property, name, context }: {
+  { children, showUsage, property, name, isReExport, context }: {
     children: Child<DocNode[]>;
     showUsage: boolean;
     property?: string;
     name: string;
+    isReExport: boolean;
     context: Context;
   },
 ) {
@@ -111,6 +118,10 @@ function Symbol(
   const isFunction = docNodes[0].kind === "function";
 
   const tags = [];
+
+  if (isReExport) {
+    tags.push(tagVariants.reExportLg());
+  }
 
   const jsDocTags: string[] = docNodes.flatMap(({ jsDoc }) =>
     (jsDoc?.tags?.filter(({ kind }) => kind === "tags") as


### PR DESCRIPTION
Currently, if there is a re-export, at times an import symbol is displayed (see bottom of https://deno.land/x/oak@v12.5.0/mod.ts?s=etag.calculate)
This PR changes this to instead show
<img width="278" alt="Screenshot 2023-06-26 at 01 02 03" src="https://github.com/denoland/doc_components/assets/13135287/5704a4ce-9a8c-4444-8121-c89d6b8b65d6">
