### PR TITLE
chore: replace empty fragment components with null

### DIFF
--- a/doc/classes.tsx
+++ b/doc/classes.tsx
@@ -201,7 +201,7 @@ function ClassMethodDoc(
     const id = nameToId("method", `${defs[0].name}_${i}`);
 
     if (functionDef.hasBody && i !== 0) {
-      return <></>;
+      return null;
     }
 
     const tags = [];
@@ -311,7 +311,7 @@ function ClassItemsDoc(
 ) {
   const defs = take(children, true);
   if (!defs.length) {
-    return <></>;
+    return null;
   }
 
   const properties: unknown[] = [];

--- a/doc/functions.tsx
+++ b/doc/functions.tsx
@@ -67,7 +67,7 @@ function DocFunctionOverload({
   const def = take(children, true);
 
   if (def.functionDef.hasBody && i !== 0) {
-    return <></>;
+    return null;
   }
 
   context.typeParams = def.functionDef.typeParams.map(({ name }) => name);
@@ -235,7 +235,7 @@ export function DocBlockFunction(
 
   const items = defs.map((def, i) => {
     if (def.functionDef.hasBody && i !== 0) {
-      return <></>;
+      return null;
     }
 
     return <DocFunction n={i} context={context}>{def}</DocFunction>;
@@ -245,7 +245,7 @@ export function DocBlockFunction(
     <div class={style("docBlockItems")}>
       {defs.map((def, i) => {
         if (def.functionDef.hasBody && i !== 0) {
-          return <></>;
+          return null;
         }
 
         const id = nameToId("function", def.name);

--- a/doc/interfaces.tsx
+++ b/doc/interfaces.tsx
@@ -259,7 +259,7 @@ export function DocSubTitleInterface(
   const { interfaceDef } = take(children);
 
   if (interfaceDef.extends.length === 0) {
-    return <></>;
+    return null;
   }
 
   return (

--- a/doc/library_doc_panel.tsx
+++ b/doc/library_doc_panel.tsx
@@ -188,7 +188,7 @@ export function LibraryDocPanel(
   }
 
   if (entries.length === 0) {
-    return <></>;
+    return null;
   }
   return (
     <div class={style("moduleIndexPanel")}>

--- a/doc/module_index.tsx
+++ b/doc/module_index.tsx
@@ -106,7 +106,7 @@ export function ModuleIndex(
   }
 
   if (entries.length === 0) {
-    return <></>;
+    return null;
   }
   return (
     <div class={style("moduleIndex")}>

--- a/doc/module_index_panel.tsx
+++ b/doc/module_index_panel.tsx
@@ -188,7 +188,7 @@ export function ModuleIndexPanel(
     }
   }
   if (entries.length === 0) {
-    return <></>;
+    return null;
   }
   return (
     <div class={style("moduleIndexPanel")}>

--- a/doc/types.tsx
+++ b/doc/types.tsx
@@ -666,7 +666,7 @@ export function DocTypeParamsSummary(
 ) {
   const typeParams = take(children, true);
   if (typeParams.length === 0) {
-    return <></>;
+    return null;
   }
 
   return (


### PR DESCRIPTION
The proper value for "nothing" is `null` instead of an empty fragment component.